### PR TITLE
feat(auth): Añade callback en inicio de sesion con google

### DIFF
--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -1,5 +1,7 @@
 import type { NextAuthConfig } from 'next-auth';
 
+import database from './db';
+
 export const authConfig = {
   session: {
     strategy: 'jwt',
@@ -15,6 +17,27 @@ export const authConfig = {
       const isAuthenticated = !!auth?.user;
 
       return isAuthenticated;
+    },
+    async signIn({ user, account }) {
+      try {
+        if (account?.provider === 'google') {
+          console.log(user);
+          await database.user.upsert({
+            where: { email: user.email! },
+            update: {},
+            create: {
+              email: user.email,
+              name: user.name,
+              image: user.image,
+              id: user.id,
+            },
+          });
+        }
+        return true;
+      } catch (error) {
+        console.error('SignIn error:', error);
+        return false;
+      }
     },
     async jwt({ token, user }) {
       if (user) {


### PR DESCRIPTION
## 📄: Descripción

- Persistir datos de usuario después de un inicio de sesión exitoso con Google.

**Problema relacionado:** Usuarios autenticados mediante el proveedor de google no se creaban en la abse de datos y el wizard para configurar la moneda por defecto fallaba al no tener el id.
 
**Cambios realizados:**
- Añade en el callback sigIn de google dentro del auth.config una validacion para crear el usuario de google en la base de datos

